### PR TITLE
(PE-26228) Allow lists of maps in snapshot schema

### DIFF
--- a/src/puppetlabs/analytics_client/core.clj
+++ b/src/puppetlabs/analytics_client/core.clj
@@ -20,10 +20,16 @@
 (def ScalarValue
   (schema/cond-pre schema/Str schema/Num schema/Bool))
 
+(def MapValue
+  {schema/Str ScalarValue})
+
+(def ListValue
+  [(schema/cond-pre MapValue ScalarValue)])
+
 (def FieldValue
   (schema/cond-pre
-   [ScalarValue]  ; Should all be the same but not easy in schema
-   {schema/Keyword ScalarValue}
+   ListValue
+   MapValue
    ScalarValue))
 
 (def Metadata

--- a/test/puppetlabs/analytics_client/core_test.clj
+++ b/test/puppetlabs/analytics_client/core_test.clj
@@ -112,11 +112,13 @@
             url (add-analytics-service app "/analytics/v1/api" promise)
             config {:analytics {:url url
                                 :ssl-opts ssl-opts}}
-            analytics {:fields {:abc.def.ghi 123}}
+            analytics {:fields {:abc.def.ghi 123
+                                :foo [{"bar" "baz"}]}}
             result (core/store-snapshot config analytics)
             params (check-promise promise result)]
         (is (= (get result "status") "success"))
-        (is (= params {"fields" {"abc.def.ghi" 123}}))))
+        (is (= params {"fields" {"abc.def.ghi" 123
+                                 "foo" [{"bar" "baz"}]}}))))
 
    (testing "Fails when provided an incorrect URL"
      (with-test-logging


### PR DESCRIPTION
This allows components to submit data that is already formatted for
insertion into a database, rather that relying on later steps in the
data pipeline to do that transformation.