### PR TITLE
(maint) update clj-parent to 5.2.6, prepare for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.9.1
+lein: 2.9.10
 jdk:
   - openjdk8
   - openjdk11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
-All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [1.2.0]
+* updated to clj-parent 5.2.6 which includes the renamed bouncy castle library based on `18on` instead of `15on`
 
 ## [1.0.0] - 2019-04-12
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
    :password :env/clojars_jenkins_password
    :sign-releases false})
 
-(defproject puppetlabs/analytics-client "1.1.2-SNAPSHOT"
+(defproject puppetlabs/analytics-client "1.2.0-SNAPSHOT"
   :description "A library for submitting metrics to the trapperkeeper analytics service."
   :url "https://github.com/puppetlabs/analytics-client"
   :license {:name "Eclipse Public License"
@@ -14,13 +14,14 @@
                  [prismatic/schema]
                  [puppetlabs/http-client]
                  [cheshire]]
-  :profiles {:defaults {:source-paths ["dev"]
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
+             :defaults {:source-paths ["dev"]
                         :dependencies [[puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                        [puppetlabs/trapperkeeper]
                                        [puppetlabs/kitchensink :classifier "test" :scope "test"]
                                        [puppetlabs/trapperkeeper-webserver-jetty9]
                                        [ring-mock "0.1.5"]]}
-             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}]
+             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
              :fips [:defaults {:dependencies [[org.bouncycastle/bctls-fips]
                                               [org.bouncycastle/bcpkix-fips]
                                               [org.bouncycastle/bc-fips]]
@@ -35,7 +36,7 @@
                                                   (throw unsupported-ex))
                                               11 ["-Djava.security.properties==./dev-resources/java.security.jdk11-fips"]
                                               (throw unsupported-ex)))}]}
-  :parent-project {:coords [puppetlabs/clj-parent "4.9.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.6"]
                    :inherit [:managed-dependencies]}
   :plugins [[lein-parent "0.3.8"]]
 


### PR DESCRIPTION
This updates the clj-parent version to 5.2.6, which allows the use of the `18on` version of the bouncycastle libraries, as opposed to the `15on` version.  It also updates the CHANGELOG in preparation for a release.